### PR TITLE
Add memory estimate

### DIFF
--- a/gap_fit.f95
+++ b/gap_fit.f95
@@ -74,6 +74,7 @@ program gap_fit_program
   call fit_n_from_xyz(main_gap_fit) ! counts number of energies, forces, virials. computes number of descriptors and gradients.
   call gap_fit_distribute_tasks(main_gap_fit)
   if (main_gap_fit%task_manager%n_workers > 1) call fit_n_from_xyz(main_gap_fit)
+  call gap_fit_estimate_memory(main_gap_fit)
 
   call set_baselines(main_gap_fit) ! sets e0 etc.
 

--- a/gap_fit_module.f95
+++ b/gap_fit_module.f95
@@ -145,6 +145,7 @@ module gap_fit_module
   public :: gap_fit_is_root
 
   public :: gap_fit_print_linear_system_dump_file
+  public :: gap_fit_estimate_memory
 
 contains
 
@@ -817,7 +818,7 @@ contains
       call print_title("Report on number of descriptors found")
       do i = 1, this%n_coordinate
          call print("---------------------------------------------------------------------")
-         call print("Descriptor: "//this%gap_str(i))
+         call print("Descriptor "//i//": "//this%gap_str(i))
          call print("Number of descriptors:                        "//this%n_descriptors(i))
          call print("Number of partial derivatives of descriptors: "//this%n_cross(i))
       enddo
@@ -2111,5 +2112,80 @@ contains
       call gpFull_print_covariances_lambda(this%my_gp, this%linear_system_dump_file, this%mpi_obj%my_proc)
     end if
   end subroutine gap_fit_print_linear_system_dump_file
+
+  subroutine gap_fit_estimate_memory(this)
+    type(gap_fit), intent(in) :: this
+
+    integer(idp), parameter :: mega = 10**6
+    integer(idp), parameter :: rmem = storage_size(1.0_dp, idp) / 8_idp
+
+    integer :: i
+    integer(idp) :: s1, s2, entries
+    integer(idp) :: mem, memt, memp1  ! scratch, total, peak
+    integer(idp) :: sys_total_mem, sys_free_mem
+
+    call print_title("Memory Estimate (per process)")
+    
+    call print("Descriptors")
+    memt = 0
+    do i = 1, this%n_coordinate
+      s1 = descriptor_dimensions(this%my_descriptor(i))
+
+      entries = s1 * this%n_descriptors(i)
+      mem = entries * rmem
+      memt = memt + mem
+      call print("Descriptor "//i//" :: x "//s1//" "//this%n_descriptors(i)//" memory "//mem/mega//" MB")
+
+      entries = s1 * this%n_cross(i)
+      mem = entries * rmem
+      memt = memt + mem
+      call print("Descriptor "//i//" :: xPrime "//s1//" "//this%n_cross(i)//" memory "//mem/mega//" MB")
+    end do
+    call print("Subtotal "//memt/mega//" MB")
+    call print("")
+    memp1 = memt
+
+
+    call print("Covariances")
+    memt = 0
+    s1 = sum(this%config_type_n_sparseX)
+    s2 = (this%n_ener + this%n_local_property) + (this%n_force + this%n_virial + this%n_hessian)
+
+    entries = s1 * s2
+    mem = entries * rmem
+    memt = memt + mem * 2
+    call print("yY "//s1//" "//s2//" memory "//mem/mega//" MB * 2")
+    memp1 = memp1 + mem
+
+    entries = s1 * s1
+    mem = entries * rmem
+    memt = memt + mem
+    call print("yy "//s1//" "//s1//" memory "//mem/mega//" MB")
+
+    entries = s1 * (s1 + s2)
+    mem = entries * rmem
+    memt = memt + mem * 2
+    call print("A "//s1//" "//s1+s2//" memory "//mem/mega//" MB * 2")
+    call print("Subtotal "//memt/mega//" MB")
+    call print("")
+
+    
+    mem = max(memp1, memt)
+    call print("Peak1 "//memp1/mega//" MB")
+    call print("Peak2 "//memt/mega//" MB")
+    call print("PEAK  "//mem/mega//" MB")
+    call print("")
+
+    call mem_info(sys_total_mem, sys_free_mem)
+    call print("Free system memory  "//sys_free_mem/mega//" MB")
+    call print("Total system memory "//sys_total_mem/mega//" MB")
+
+    mem = sys_free_mem - mem
+    if (mem < 0) then
+      call print_warning("Memory estimate exceeds free system memory by "//-mem/mega//" MB.")
+    end if
+
+    call print_title("")
+  end subroutine gap_fit_estimate_memory
 
 end module gap_fit_module


### PR DESCRIPTION
### Example output

```
========================= Memory Estimate (per process) ========================

Descriptors
Descriptor 1 :: x 325 2619 memory 6 MB
Descriptor 1 :: xPrime 325 348021 memory 904 MB
Subtotal 911 MB

Covariances
yY 500 8060 memory 32 MB * 2
yy 500 500 memory 2 MB
A 500 8560 memory 34 MB * 2
Subtotal 134 MB

Peak1 943 MB
Peak2 134 MB
PEAK  943 MB

Free system memory  1522 MB
Total system memory 16311 MB

========================================  ======================================
```

### Notes

- Memory estimate for largest arrays (mostly rank 2 matrices). Factors 2 for duplicates. Should be changed when we deduplicate.
- As is, "TOTAL" makes sense. When early free is introduced, it's not that helpful anymore.

### Questions

- [ ] Add option to unconditionally abort after estimate?
- [ ] Add option to conditionally abort if estimate > free memory (prone to error)?
- [ ] Round memory to next lowest SI prefactor?
