### PR TITLE
Free x, xPrime early

### DIFF
--- a/gp_predict.f95
+++ b/gp_predict.f95
@@ -1550,6 +1550,14 @@ module gp_predict_module
             RAISE_ERROR('gpFull_covarianceMatrix: '//i_coordinate//'th coordinate object not sparsified',error)
          endif
 
+         if( .not. allocated(this%coordinate(i_coordinate)%x) ) then
+            RAISE_ERROR('gpFull_covarianceMatrix: '//i_coordinate//"th coordinate's x not allocated",error)
+         endif
+
+         if( .not. allocated(this%coordinate(i_coordinate)%xPrime) ) then
+            RAISE_ERROR('gpFull_covarianceMatrix: '//i_coordinate//"th coordinate's xPrime not allocated",error)
+         endif
+
          if(this%coordinate(i_coordinate)%covariance_type == COVARIANCE_BOND_REAL_SPACE) then
             if(.not. this%coordinate(i_coordinate)%bond_real_space_cov%initialised) then  
                call gpCoordinates_gpCovariance_bond_real_space_Initialise(this%coordinate(i_coordinate))
@@ -1822,6 +1830,8 @@ module gp_predict_module
             this%covarianceDiag_y_y = 0.0_dp
          endselect
 
+         if (allocated(this%coordinate(i_coordinate)%x)) deallocate(this%coordinate(i_coordinate)%x)
+         if (allocated(this%coordinate(i_coordinate)%xPrime)) deallocate(this%coordinate(i_coordinate)%xPrime)
          call system_timer('gpFull_covarianceMatrix_sparse_Coordinate'//i_coordinate)
       enddo
 


### PR DESCRIPTION
Deallocate gpFull's `x` and `xPrime` after last use in `gpFull_covariance_sparse`.

1. I stripped the dev implementation down to this barebones one. Removed gap_fit argument and memory size printing. Could be added again but if there is no information to compare it with, it's not really that useful. The estimate in #19 is probably enough.
2. Added the allocated check. Are there other spots where this should be checked?
3. Still thinking if it's worth it to put all coord loops together so two big x/xprim matrices are not allocated at the same time. Would decrease the memory peak even more.
4. Further savings can be made in the QR solver but the peak would probably not change before 3 is included.

### Example for HT4865 test (without PR)

Memory logger
```
before   38 GB
steady1 602 GB (+564 GB)
steady2 735 GB (+133 GB)
steady3 859 GB (+124 GB)
steady4 984 GB (+125 GB)
after    38 GB (-946 GB)
```

Estimate:
```
Descriptor 4 :: x 681 404066 memory 2 GB
Descriptor 4 :: xPrime 681 49919139 memory 271 GB
Descriptor 5 :: x 681 411944 memory 2 GB
Descriptor 5 :: xPrime 681 54166167 memory 295 GB
Subtotal 575 GB

yY 3300 2482085 memory 65 GB * 2 (=130 GB)
yy 3300 3300 memory 87 MB
A 3300 2482085 memory 65 GB * 2  (=130 GB)
Subtotal 262 GB

TOTAL 837 GB
```