### PR TITLE
Fix: mpi xyz index

### DIFF
--- a/gap_fit_module.f95
+++ b/gap_fit_module.f95
@@ -653,7 +653,7 @@ contains
        call system_abort("read_fit_xyz: at_file "//this%at_file//" could not be found")
     endif
 
-    call initialise(xyzfile,this%at_file,no_compute_index=this%task_manager%active)
+    call initialise(xyzfile,this%at_file,mpi=this%mpi_obj)
     this%n_frame = xyzfile%n_frame
 
     allocate(this%at(this%n_frame))
@@ -1482,7 +1482,7 @@ contains
     type(cinoutput) :: xyzfile
     type(atoms) :: at
 
-    call initialise(xyzfile,this%at_file,no_compute_index=this%task_manager%active)
+    call initialise(xyzfile,this%at_file,mpi=this%mpi_obj)
 
     call read(xyzfile,at,frame=0)
     !call get_weights(at,this%w_Z)

--- a/gap_fit_module.f95
+++ b/gap_fit_module.f95
@@ -666,6 +666,10 @@ contains
 
     call finalise(xyzfile)
 
+    if(this%n_frame <= 0) then
+      call system_abort("read_fit_xyz: "//this%n_frame//" frames read from "//this%at_file//".")
+   endif
+
   endsubroutine read_fit_xyz
 
   subroutine read_descriptors(this)


### PR DESCRIPTION
The previous fix for the `*.idx` problem did not work. `no_compute_index = .true.` leads to `n_frame = 0`.

- Have only root handle initial index
- Check for no frames