### PR TITLE
fix(mpi): allocate counts for non-roots

### DIFF
--- a/gp_predict.f95
+++ b/gp_predict.f95
@@ -938,6 +938,8 @@ module gp_predict_module
       if (do_subY_subY) then
          factor_c_subYsubY = transpose(factor_c_subYsubY)
          call get_shared_task_counts(task_manager, n_globalSparseX, counts)
+      else
+         allocate(counts(1), source=0)
       end if
 
       w = task_manager%my_worker_id


### PR DESCRIPTION
While scatterv counts should not be needed for non-root processes,
there seems to be a compiler-specific problem on at least one cluster.

Thanks to Harry for bringing this to my attention.