### PR TITLE
Bugfix for "Runtime errors with fcheck (GAP descriptors)"

### DIFF
--- a/descriptors.f95
+++ b/descriptors.f95
@@ -2510,8 +2510,9 @@ module descriptors_module
       ! backwards compatibility: the default used to be different before this version number
       if( xml_version < 1426512068 ) this%central_reference_all_species = .true.
 
-      allocate(this%species_Z(this%n_species))
+      allocate(this%species_Z(0:this%n_species))
       allocate(this%Z(this%n_Z))
+      this%species_Z(0)=0
 
       if( has_species_Z .and. .not. has_n_species ) then
          RAISE_ERROR("soap_initialise: is species_Z is present, n_species must be present, too.",error)
@@ -2535,7 +2536,7 @@ module descriptors_module
          if(this%n_species == 1) then
             call param_register(params, 'species_Z', '0', this%species_Z(1), help_string="Atomic number of species")
          else
-            call param_register(params, 'species_Z', '//MANDATORY//', this%species_Z, help_string="Atomic number of species")
+            call param_register(params, 'species_Z', '//MANDATORY//', this%species_Z(1:this%n_species), help_string="Atomic number of species")
          endif
       else
          call param_register(params, 'species_Z', '0', this%species_Z(1), help_string="Atomic number of species")
@@ -7534,8 +7535,7 @@ module descriptors_module
          do i_species = 0, this%n_species
             do a = 0, this%n_max
                !SPEED fourier_so3(0,a,i_species)%m(0) = radial_coefficient(0,a) * SphericalYCartesian(0,0,(/0.0_dp, 0.0_dp, 0.0_dp/))
-
-               if (i_species == 0 .or.  this%central_reference_all_species .or. this%species_Z(i_species) == at%Z(i) .or. this%species_Z(i_species) == 0) then
+               if (i_species == 0 .or. this%central_reference_all_species .or. this%species_Z(i_species) == at%Z(i) .or. this%species_Z(i_species) == 0) then
                   if (a == 0) then
                      fourier_so3_r(0,a,i_species)%m(0) = this%central_weight * real( SphericalYCartesian(0,0,(/0.0_dp, 0.0_dp, 0.0_dp/)), dp)
                      fourier_so3_i(0,a,i_species)%m(0) = this%central_weight * aimag( SphericalYCartesian(0,0,(/0.0_dp, 0.0_dp, 0.0_dp/)))

--- a/descriptors.f95
+++ b/descriptors.f95
@@ -7535,7 +7535,8 @@ module descriptors_module
          do i_species = 0, this%n_species
             do a = 0, this%n_max
                !SPEED fourier_so3(0,a,i_species)%m(0) = radial_coefficient(0,a) * SphericalYCartesian(0,0,(/0.0_dp, 0.0_dp, 0.0_dp/))
-               if (i_species == 0 .or. this%central_reference_all_species .or. this%species_Z(i_species) == at%Z(i) .or. this%species_Z(i_species) == 0) then
+
+               if (i_species == 0 .or.  this%central_reference_all_species .or. this%species_Z(i_species) == at%Z(i) .or. this%species_Z(i_species) == 0) then
                   if (a == 0) then
                      fourier_so3_r(0,a,i_species)%m(0) = this%central_weight * real( SphericalYCartesian(0,0,(/0.0_dp, 0.0_dp, 0.0_dp/)), dp)
                      fourier_so3_i(0,a,i_species)%m(0) = this%central_weight * aimag( SphericalYCartesian(0,0,(/0.0_dp, 0.0_dp, 0.0_dp/)))


### PR DESCRIPTION
To resolve [#499](https://github.com/libAtoms/QUIP/issues/499)

I've extended `this%species_Z` to start from 0.  This shouldn't cause an issue as `SIZE(this%species_Z)` doesn't get called and the only places ` this%species_Z(0)` should be accessed relate to the compression. Checked that gradient tests still pass.