### PR TITLE
Add config_string to XML

### DIFF
--- a/gap_fit_module.f95
+++ b/gap_fit_module.f95
@@ -1610,18 +1610,12 @@ contains
         call gp_printXML(this%gp_sp,xf,label=gp_label)
      endif
 
-     ! Print the command line used for the fitting
-     if(len(trim(this%command_line))> 0 ) then
+     ! Print the config string (from command line or config file) used for the fitting
+     ! Keep <command_line> for backwards compatibility
+     if(this%config_string%len > 0) then
         call xml_NewElement(xf,"command_line")
-        call xml_AddCharacters(xf,trim(this%command_line),parsed=.false.)
+        call xml_AddCharacters(xf,trim(string(this%config_string)),parsed=.false.)
         call xml_EndElement(xf,"command_line")
-     endif
-
-     ! Print config file content
-     if (this%has_config_file) then
-        call xml_NewElement(xf,"config_string")
-        call xml_AddCharacters(xf,string(this%config_string),parsed=.false.)
-        call xml_EndElement(xf,"config_string")
      endif
 
      if(this%do_copy_at_file) then

--- a/gap_fit_module.f95
+++ b/gap_fit_module.f95
@@ -228,7 +228,7 @@ contains
         if (has_config_file) then
            inquire(file=config_file, exist=file_exists)
            if (.not. file_exists) call system_abort("Config file does not exist: "//config_file)
-           call read(this%config_string, config_file, keep_lf=.false., mpi_comm=this%mpi_obj%communicator, mpi_id=this%mpi_obj%my_proc)
+           call read(this%config_string, config_file, keep_lf=.true., mpi_comm=this%mpi_obj%communicator, mpi_id=this%mpi_obj%my_proc)
         end if
      end if
      if (.not. has_config_file) this%config_string = this%command_line
@@ -358,7 +358,7 @@ contains
      call param_register(params, 'mpi_print_all', 'F', mpi_print_all, &
           help_string="If true, each MPI processes will print its output. Otherwise, only the first process does (default).")
 
-     if (.not. param_read_line(params, string(this%config_string))) then
+     if (.not. param_read_line(params, replace(string(this%config_string), quip_new_line, ' '))) then
         call system_abort('Exit: Mandatory argument(s) missing...')
      endif
 


### PR DESCRIPTION
Realted to https://github.com/libAtoms/QUIP/pull/507

Add `<config_string>` to XML output in addition to `<command_line>` if `config_file=` was used. This uses the parsed file, i.e. all newlines have been replaced with spaces.

### Example

#### Version 1 (add `<config_string>`)

##### Without `config_file=`

```
<command_line><![CDATA[ at_file=train_sub3.xyz gap={soap l_max=8 n_max=8 atom_sigma=0.5 zeta=4 cutoff=4.0 cutoff_transition_width=1.0 central_weight=1.0 n_sparse=500 delta=3.0 f0=0.0 covariance_type=dot_product sparse_method=FILE sparse_file=1.input} default_sigma={0.001 0.1 0.05 0.0} energy_parameter_name=dft_energy force_parameter_name=dft_force virial_parameter_name=dft_virial config_type_parameter_name=config_type sparse_jitter=1.0e-6 e0_offset=2.0 gp_file=gp_file.xml rnd_seed=1]]></command_line>
```

##### With `config_file`

```
<command_line><![CDATA[ config_file=config_file]]></command_line>
<config_string><![CDATA[at_file=train_sub3.xyz gap={   {soap l_max=8 n_max=8 atom_sigma=0.5 zeta=4 cutoff=4.0 cutoff_transition_width=1.0 central_weight=1.0 n_sparse=500 delta=3.0 f0=0.0 covariance_type=dot_product sparse_method=FILE sparse_file=1.input} } default_sigma={0.001 0.1 0.05 0.0} energy_parameter_name=dft_energy force_parameter_name=dft_force virial_parameter_name=dft_virial config_type_parameter_name=config_type sparse_jitter=1.0e-6 e0_offset=2.0 gp_file=gp_file.xml rnd_seed=1]]></config_string>
```

#### Version 2 (only `<command_line>` without newlines)

##### Without `config_file=`

```
<command_line><![CDATA[ at_file=train_sub3.xyz gap={soap l_max=8 n_max=8 atom_sigma=0.5 zeta=4 cutoff=4.0 cutoff_transition_width=1.0 central_weight=1.0 n_sparse=500 delta=3.0 f0=0.0 covariance_type=dot_product sparse_method=FILE sparse_file=1.input} default_sigma={0.001 0.1 0.05 0.0} energy_parameter_name=dft_energy force_parameter_name=dft_force virial_parameter_name=dft_virial config_type_parameter_name=config_type sparse_jitter=1.0e-6 e0_offset=2.0 gp_file=gp_file.xml rnd_seed=1]]></command_line>
```

##### With `config_file`

```
<command_line><![CDATA[at_file=train_sub3.xyz gap={   {soap l_max=8 n_max=8 atom_sigma=0.5 zeta=4 cutoff=4.0 cutoff_transition_width=1.0 central_weight=1.0 n_sparse=500 delta=3.0 f0=0.0 covariance_type=dot_product sparse_method=FILE sparse_file=1.input} } default_sigma={0.001 0.1 0.05 0.0} energy_parameter_name=dft_energy force_parameter_name=dft_force virial_parameter_name=dft_virial config_type_parameter_name=config_type sparse_jitter=1.0e-6 e0_offset=2.0 gp_file=gp_file.xml rnd_seed=1]]></command_line>
```

#### Version 3 (only `<command_line>` with newlines)

##### With `config_file`

```
<command_line><![CDATA[at_file=train_sub3.xyz
gap={
  {soap l_max=8 n_max=8 atom_sigma=0.5 zeta=4 cutoff=4.0 cutoff_transition_width=1.0 central_weight=1.0 n_sparse=500 delta=3.0 f0=0.0 covariance_type=dot_product sparse_method=FILE sparse_file=1.input}
}
default_sigma={0.001 0.1 0.05 0.0}
energy_parameter_name=dft_energy
force_parameter_name=dft_force
virial_parameter_name=dft_virial
config_type_parameter_name=config_type
sparse_jitter=1.0e-6
e0_offset=2.0
gp_file=gp_file.xml
rnd_seed=1
]]></command_line>
```

### Alternatives

- rename to `<config_file>`
- print the original file, i.e. with new lines
- always print `config_string`, even if it is identical to `command_line` so that you can parse the same item
