### PR TITLE
Fix: Update GHA checkout to v3

### DIFF
--- a/.github/workflows/ci_hybrid-md.yaml
+++ b/.github/workflows/ci_hybrid-md.yaml
@@ -16,7 +16,7 @@ jobs:
       max-parallel: 5
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
Related to https://github.com/libAtoms/QUIP/pull/537