### PR TITLE
Hotfix: hybrid md ci & castep v22 compat

### DIFF
--- a/.github/workflows/ci_hybrid-md.yaml
+++ b/.github/workflows/ci_hybrid-md.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10"]
       max-parallel: 5
 
     steps:

--- a/.github/workflows/ci_hybrid-md.yaml
+++ b/.github/workflows/ci_hybrid-md.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, 3.10, 3.11 ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
       max-parallel: 5
 
     steps:

--- a/hybrid_md_package/hybrid_md/cli.py
+++ b/hybrid_md_package/hybrid_md/cli.py
@@ -28,7 +28,7 @@ def main():
 
 @main.command("initialise")
 @click.argument("seed", type=click.STRING)
-@click.argument("md-iteration", type=click.INT)
+@click.argument("md-iteration", type=click.INT, default=0)
 def initialise(seed, md_iteration):
     """Initialisation of the Hybrid MD run.
 


### PR DESCRIPTION
Follow up of #72, mostly a hotfix - I have realised that we will be advertising castep v22 compatibility, for which a default value (initial MD step number) needed setting in the CLI which is irrelevant for castep v23 where we are passing this.

I have also eliminated python 3.11 from the CI, which some dependency is not compatible with as it seems. This is a "wontfix" issue, the dependency developers will sort it out over time.