### PR TITLE
WIP: Fix distance_nb bug

### DIFF
--- a/gap_fit_module.f95
+++ b/gap_fit_module.f95
@@ -232,7 +232,7 @@ contains
         if (has_config_file) then
            inquire(file=config_file, exist=file_exists)
            if (.not. file_exists) call system_abort("Config file does not exist: "//config_file)
-           call read(this%config_string, config_file, keep_lf=.true., mpi_comm=this%mpi_obj%communicator, mpi_id=this%mpi_obj%my_proc)
+           call read(this%config_string, config_file, keep_lf=.false., mpi_comm=this%mpi_obj%communicator, mpi_id=this%mpi_obj%my_proc)
         end if
      end if
      if (.not. has_config_file) this%config_string = this%command_line

--- a/gp_fit.f95
+++ b/gp_fit.f95
@@ -457,7 +457,7 @@ module gp_fit_module
 
       inquire(file=trim(sparse_file), exist=exist_sparse_file)
       if (.not. exist_sparse_file) then
-         RAISE_ERROR('count_entries_in_sparse_file: '//trim(sparse_file)//' does not exist', error)
+         RAISE_ERROR('count_entries_in_sparse_file: "'//trim(sparse_file)//'" does not exist', error)
       end if
 
       call fwc_l(trim(sparse_file)//C_NULL_CHAR, n_sparse_file)


### PR DESCRIPTION
fixed permuational invariance bug for order>2 distance_nb:

1. order the atoms belonging to a cluster according their Zs, so that they appear in the same order as in the Z template
2. multiply all pair-wise bond cutoffs together

TODO: add version check to stop old versions from being run.